### PR TITLE
Add SDTC race codes

### DIFF
--- a/lib/cda/models/patient.rb
+++ b/lib/cda/models/patient.rb
@@ -9,6 +9,7 @@ class Cda::Patient < Cda::Base
   attribute :marital_status_code, Cda::CE
   attribute :religious_affiliation_code, Cda::CE
   attribute :race_code, Cda::CE
+  attribute :sdtc_race_code, Array[Cda::CE], annotations: {multiple: true}
   attribute :ethnic_group_code, Cda::CE
   attribute :guardian, Array[Cda::Guardian], annotations: {:multiple=>true}
   attribute :birthplace, Cda::Birthplace

--- a/ruby-cda.gemspec
+++ b/ruby-cda.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'ruby-cda'
-  s.version     = '0.1.5'
+  s.version     = '0.1.0'
   s.licenses    = ['MIT']
   s.summary     = "HL7 CDA Documents"
   s.description = "Parse & generation of HL7 cda documents"

--- a/ruby-cda.gemspec
+++ b/ruby-cda.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'ruby-cda'
-  s.version     = '0.0.1'
+  s.version     = '0.1.5'
   s.licenses    = ['MIT']
   s.summary     = "HL7 CDA Documents"
   s.description = "Parse & generation of HL7 cda documents"
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files       = `git ls-files lib`.split($/)
   s.homepage    = 'https://github.com/niquola/ruby-cda'
 
-  s.add_dependency 'activesupport', '>= 5.0'
+  s.add_dependency 'activesupport', '~> 5.0'
   s.add_dependency 'nokogiri',      '~> 1.6'
   s.add_dependency 'virtus',        '~> 1.0'
   s.add_dependency 'i18n',          '~> 1'


### PR DESCRIPTION
See: https://github.com/IoraHealth/IoraHealth/pull/6948

The gist of the problem here is that this library doesn't support our name-spaced attributes if the attribute has the same name or if the namespace is declared at the top level node. We have both) 

The approach here is to add sdtc_race_codes to the patient attributes and then replace them later with nokogiri to have the proper namespacnig