### PR TITLE
Add SDTC ethnic codes

### DIFF
--- a/lib/cda/models/patient.rb
+++ b/lib/cda/models/patient.rb
@@ -10,6 +10,7 @@ class Cda::Patient < Cda::Base
   attribute :religious_affiliation_code, Cda::CE
   attribute :race_code, Cda::CE
   attribute :ethnic_group_code, Cda::CE
+  attribute :sdtc_ethnic_group_code, Array[Cda::CE], annotations: { multiple: true }
   attribute :guardian, Array[Cda::Guardian], annotations: {:multiple=>true}
   attribute :birthplace, Cda::Birthplace
   attribute :language_communication, Array[Cda::LanguageCommunication], annotations: {:multiple=>true}

--- a/ruby-cda.gemspec
+++ b/ruby-cda.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'ruby-cda'
-  s.version     = '0.0.1'
+  s.version     = '0.1.1'
   s.licenses    = ['MIT']
   s.summary     = "HL7 CDA Documents"
   s.description = "Parse & generation of HL7 cda documents"


### PR DESCRIPTION
Why:
- We are going to use this code attribute to store the additional
  ethnic_group_codes we have for a patient. After the xml is generated
  we will rename the xml node to be the correct `sdtc:ethnicGroupCode`
  format.

See: https://github.com/IoraHealth/IoraHealth/pull/6956