### PR TITLE
Add extensions to Assessment, Plan of Care, Referral Note sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- 0.2.7
+
+  - Extensions added for Plan of Care and Assessment sections that the validator tells us are required
+
 - 0.2.6
 
   - Extensions added for Result Organizer and Observation that the validator tells us are required

--- a/lib/ccd/templates/assessment_section_template.rb
+++ b/lib/ccd/templates/assessment_section_template.rb
@@ -4,10 +4,9 @@ module Ccd::AssessmentSectionTemplate
       extend ::Ccd::Dsl
       
       # SHALL contain exactly one [1..1] templateId (CONF:7711) such that it
-      constraint 'template_id', {:cardinality=>"1..1"}
-      
       # SHALL contain exactly one [1..1] @root="2.16.840.1.113883.10.20.22.2.8" (CONF:10382).
-      constraint 'template_id.root', {:cardinality=>"1..1", :value=>"2.16.840.1.113883.10.20.22.2.8"}
+      constraint 'template_id', {:cardinality=>"1..1", :value=>{:root=>"2.16.840.1.113883.10.20.22.2.8"}}
+      constraint 'template_id', {:cardinality=>"1..1", :value=>{:root=>"2.16.840.1.113883.10.20.22.2.8", :extension=>"2014-06-09"}}
       
       # SHALL contain exactly one [1..1] code (CONF:14757).
       constraint 'code', {:cardinality=>"1..1", :value=>{:code=>"51848-0", :display_name=>"Assessments"}}

--- a/lib/ccd/templates/plan_of_care_section_template.rb
+++ b/lib/ccd/templates/plan_of_care_section_template.rb
@@ -4,10 +4,9 @@ module Ccd::PlanOfCareSectionTemplate
       extend ::Ccd::Dsl
       
       # SHALL contain exactly one [1..1] templateId (CONF:7723) such that it
-      constraint 'template_id', {:cardinality=>"1..1"}
-      
       # SHALL contain exactly one [1..1] @root="2.16.840.1.113883.10.20.22.2.10" (CONF:10435).
-      constraint 'template_id.root', {:cardinality=>"1..1", :value=>"2.16.840.1.113883.10.20.22.2.10"}
+      constraint 'template_id', {:cardinality=>"1..1", :value=>{:root=>"2.16.840.1.113883.10.20.22.2.10"}}
+      constraint 'template_id', {:cardinality=>"1..1", :value=>{:root=>"2.16.840.1.113883.10.20.22.2.10", :extension=>"2014-06-09"}}
       
       # SHALL contain exactly one [1..1] code (CONF:14749).
       constraint 'code', {:cardinality=>"1..1", :value=>{:code=>"18776-5", :display_name=>"Plan of Care", :code_system=>"2.16.840.1.113883.6.1"}}

--- a/lib/ccd/templates/reason_for_referral_section_template.rb
+++ b/lib/ccd/templates/reason_for_referral_section_template.rb
@@ -4,10 +4,9 @@ module Ccd::ReasonForReferralSectionTemplate
       extend ::Ccd::Dsl
       
       # SHALL contain exactly one [1..1] templateId (CONF:7844) such that it
-      constraint 'template_id', {:cardinality=>"1..1"}
-      
       # SHALL contain exactly one [1..1] @root="1.3.6.1.4.1.19376.1.5.3.1.3.1" (CONF:10468).
-      constraint 'template_id.root', {:cardinality=>"1..1", :value=>"1.3.6.1.4.1.19376.1.5.3.1.3.1"}
+      constraint 'template_id', {:cardinality=>"1..1", :value=>{:root=>"1.3.6.1.4.1.19376.1.5.3.1.3.1"}}
+      constraint 'template_id', {:cardinality=>"1..1", :value=>{:root=>"1.3.6.1.4.1.19376.1.5.3.1.3.1", :extension=>"2014-06-09"}}
       
       # SHALL contain exactly one [1..1] code (CONF:15427).
       constraint 'code', {:cardinality=>"1..1", :value=>{:code=>"42349-1", :display_name=>"Reason for Referral", :code_system=>"2.16.840.1.113883.6.1"}}

--- a/ruby-cda.gemspec
+++ b/ruby-cda.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name        = 'ruby-cda'
-  s.version     = '0.2.6'
+  s.version     = '0.2.7'
   s.licenses    = ['MIT']
   s.summary     = "HL7 CDA Documents"
   s.description = "Parse & generation of HL7 cda documents"


### PR DESCRIPTION
https://trello.com/c/vWyoHqVb

This surfaced in PI testing when validating Referral Note C-CDAs.
The change to Assessment and Plan of Care sections also affects CCDs but
does not cause additional validation errors for those CCDs.